### PR TITLE
Add full text to rss feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -14,7 +14,7 @@ layout: null
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.desc | xml_escape }}</description>
+        <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>


### PR DESCRIPTION
This commit adds full text to the RSS feed so that this...

![description rss feed](https://user-images.githubusercontent.com/37990858/80919704-7aa5df80-8da6-11ea-86e1-64a856a8a5c0.png)

becomes this.

![full text rss feed](https://user-images.githubusercontent.com/37990858/80919704-7aa5df80-8da6-11ea-86e1-64a856a8a5c0.png)

This allows people to view blog entries full text in the RSS viewer.
